### PR TITLE
Fixed a few performance issues with the UI by:

### DIFF
--- a/swag_api/static/src/AccountCard.js
+++ b/swag_api/static/src/AccountCard.js
@@ -8,7 +8,8 @@ import Collapse from 'material-ui/transitions/Collapse';
 import Avatar from 'material-ui/Avatar';
 import IconButton from 'material-ui/IconButton';
 import ExpandMoreIcon from 'material-ui-icons/ExpandMore';
-
+import Tooltip from 'material-ui/Tooltip'
+import Search from 'material-ui-icons/Search';
 import List, {ListItem, ListItemText} from 'material-ui/List';
 import Table, {TableBody, TableCell, TableHead, TableRow} from 'material-ui/Table';
 
@@ -24,8 +25,6 @@ import SupervisorAccount from 'material-ui-icons/SupervisorAccount';
 import Check from 'material-ui-icons/Check';
 
 import CopyToClipboardButton from './CopyToClipboardButton';
-import ServiceDialog from './ServiceDialog';
-import JSONDialog from './JSONDialog';
 import Tabs, {Tab} from 'material-ui/Tabs';
 import green from 'material-ui/colors/green';
 import red from 'material-ui/colors/red';
@@ -113,7 +112,7 @@ class AccountCard extends Component {
     constructor(props, context) {
         super(props, context);
         this.state = {
-            expanded: true,
+            expanded: false,
             value: 0
         };
 
@@ -132,7 +131,6 @@ class AccountCard extends Component {
     render() {
         const classes = this.props.classes;
         const {value} = this.state;
-
         return (
             <div>
                 <Card className={classes.card}>
@@ -246,8 +244,16 @@ class AccountCard extends Component {
                         </CardContent>
                     </Collapse>
                     <CardActions disableActionSpacing>
-                        <ServiceDialog services={this.props.account.services}/>
-                        <JSONDialog data={this.props.account}/>
+                        <Tooltip title="Services">
+                            <IconButton onClick={this.props.openDialog(this.props.account)}>
+                                <Computer/>
+                            </IconButton>
+                        </Tooltip>
+                        <Tooltip title="JSON">
+                            <IconButton onClick={this.props.openJSON(this.props.account)}>
+                                <Search/>
+                            </IconButton>
+                        </Tooltip>
                         <div className={classes.flexGrow}/>
                         <IconButton
                             className={classnames(classes.expand, {

--- a/swag_api/static/src/AppSearchResults.js
+++ b/swag_api/static/src/AppSearchResults.js
@@ -5,7 +5,39 @@ import AccountCard from './AccountCard';
 import Error from './Error';
 import ResultLoader from './ResultLoader';
 
+import {withStyles} from 'material-ui/styles';
+import Dialog from 'material-ui/Dialog';
+import AppBar from 'material-ui/AppBar';
+import Toolbar from 'material-ui/Toolbar';
+import ArrowBack from 'material-ui-icons/ArrowBack';
+import Slide from 'material-ui/transitions/Slide';
+import ServiceCard from './ServiceCard';
+import IconButton from 'material-ui/IconButton';
+import Typography from 'material-ui/Typography';
+import ReactJson from 'react-json-view';
 
+const styles = {
+    appBar: {
+        position: 'relative',
+    },
+    flex: {
+        flex: 1,
+    },
+    container: {
+        padding: '16px',
+        fontWeight: '500',
+        boxSizing: 'border-box',
+        position: 'relative',
+        whiteSpace: 'nowrap',
+        overflow: 'auto'
+    },
+    content: {
+        display: 'flex',
+        flexDirection: 'column',
+        flexWrap: 'no-wrap',
+        minHeight: '100vh'
+    }
+}
 const prefilters = [
     {
         regex: /.*:.*/g,
@@ -18,27 +50,97 @@ const prefilters = [
 ];
 
 
-export default class AppSearchResults extends Component {
+class AppSearchResults extends Component {
+    state = { open: false, jsonOpen: false, account: { services: []} }
+    onOpenCard = account => event => {
+      this.setState({
+        open: true,
+        account
+      })
+    }
+
+    onOpenJSON = account => event => {
+      this.setState({
+        jsonOpen: true,
+        account,
+      })
+    }
+
+    handleClose = event => {
+      this.setState({
+        open: false,
+        jsonOpen: false,
+        account: { services: [] },
+      })
+    }
+
     render() {
-        const {data} = this.props;
+        const {data, classes} = this.props;
+
         if (data.pending) {
             return <ResultLoader/>;
         } else if (data.rejected) {
             return <Error status={data.rejected}/>;
         } else if (data.fulfilled) {
-            return <FilterResults
-                items={data.value}
-                fuseConfig={fuseConfig}
-                prefilters={prefilters}
-            >
-                {filteredItems => {
-                    return (
-                        <div>
-                            {filteredItems.map((item) => <AccountCard key={item.id} account={item}/>)}
-                        </div>
-                    )
-                }}
+            return <div>
+              <Dialog
+                  fullScreen
+                  open={this.state.open}
+                  onRequestClose={this.handleClose}
+                  transition={<Slide direction="right"/>}
+              >
+                  <AppBar position="static">
+                      <Toolbar>
+                          <IconButton color="contrast" onClick={this.handleClose} aria-label="Close">
+                              <ArrowBack/>
+                          </IconButton>
+                          <Typography type="title" color="inherit" className={classes.flex}>
+                              Services
+                          </Typography></Toolbar>
+                  </AppBar>
+                  <div className={classes.container}>
+                      <div className={classes.content}>
+                          {this.state.account.services.map((item, index) => <ServiceCard key={index} service={item}/>)}
+                      </div>
+                  </div>
+              </Dialog>
+              <Dialog
+                  fullScreen
+                  open={this.state.jsonOpen}
+                  onRequestClose={this.handleClose}
+                  transition={<Slide direction="right"/>}
+              >
+                  <AppBar position="static">
+                      <Toolbar>
+                          <IconButton color="contrast" onClick={this.handleClose} aria-label="Close">
+                              <ArrowBack/>
+                          </IconButton>
+                          <Typography type="title" color="inherit" className={classes.flex}>
+                              Raw JSON
+                          </Typography></Toolbar>
+                  </AppBar>
+                  <div className={classes.container}>
+                      <div className={classes.content}>
+                          <ReactJson enableClipBoard={false} displayDataTypes={false} displayObjectSize={false} onEdit={true} src={this.state.account}/>
+                      </div>
+                  </div>
+              </Dialog>
+              <FilterResults
+                  items={data.value}
+                  fuseConfig={fuseConfig}
+                  prefilters={prefilters}
+              >
+                  {filteredItems => {
+                      return (
+                          <div>
+                              {filteredItems.map((item, idx) => idx > -1 ? <AccountCard openJSON={this.onOpenJSON} openDialog={this.onOpenCard} key={item.id} account={item}/> : null)}
+                          </div>
+                      )
+                  }}
             </FilterResults>
+          </div>
         }
     }
 }
+
+export default withStyles(styles)(AppSearchResults)

--- a/swag_api/static/src/FilterResults.js
+++ b/swag_api/static/src/FilterResults.js
@@ -44,11 +44,15 @@ export default function filterResultsFactory(store) {
         };
 
         state = {
-            search: null
+            search: undefined
         };
 
         componentDidMount() {
-            this.subscription = store.subscribe(search => this.setState({search}));
+            this.subscription = store.subscribe(search => {
+              if (this.state.search !== search) {
+                this.setState({search})
+              }
+            });
         }
 
         componentWillUnmount() {


### PR DESCRIPTION
 - collapsing the slide out dialogs into one instance, which reduces
overall DOM size and event listener count
 - collapse the `AccountCard` components by default, reduces DOM size and
event listener count
 - don't trigger an update in `FilterResults` if the search term hasn't
changed