### PR TITLE
Updated dependencies - Some important changes:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-boto3>=1.9.131
+boto3
 flask>=0.12.2
 raven[flask]>=6.1.0
-swag_client>=0.4.7
-flask-restplus>=0.11.0
+swag_client>=3.0.0
+flask-restx>=0.2.0
 gunicorn>=19.7.1
 flask-cors>=3.0.3
 simplejson>=3.16.0

--- a/setup.py
+++ b/setup.py
@@ -2,24 +2,14 @@
 swag-api
 ========
 
-Web interface for SWAG data.
+Web interface for SWAG data (see swag-client for details).
 
-:copyright: (c) 2017 by Netflix, see AUTHORS for more
+:copyright: (c) 2020 by Netflix, see AUTHORS for more
 :license: Apache, see LICENSE for more details.
 """
 import os
 
-from setuptools import find_packages, setup
-
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-try:  # for pip >= 10
-    from pip._internal.download import PipSession
-except ImportError:  # for pip <= 9.0.3
-    from pip.download import PipSession
-
+from setuptools import setup
 
 ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__)))
 
@@ -27,32 +17,10 @@ about = {}
 with open(os.path.join(ROOT, 'swag_api', '__about__.py')) as f:
     exec(f.read(), about)  # nosec: about file is benign
 
-
-# Gather install requirements from requirements.txt
-install_reqs = parse_requirements('requirements.txt', session=PipSession())
-install_requires = [str(ir.req) for ir in install_reqs]
-
-# Gather test requirements from requirements-test.txt
-test_reqs = parse_requirements('requirements-test.txt', session=PipSession())
-tests_requires = [str(tr.req) for tr in test_reqs]
-
-
 setup(
-    name=about["__title__"],
-    version=about["__version__"],
-    author=about["__author__"],
-    author_email=about["__email__"],
-    url=about["__uri__"],
+    name="swag-api",
     description=about["__summary__"],
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=install_requires,
-    extras_require={
-        'tests': tests_requires
-    },
-    setup_requires=[
-        'pytest-runner',
-    ],
+    setup_requires="setupmeta",
     entry_points={
         'console_scripts': [
             'swag-api=swag_api:cli.main',

--- a/swag_api/__about__.py
+++ b/swag_api/__about__.py
@@ -2,18 +2,18 @@
 from __future__ import absolute_import, division, print_function
 
 __all__ = [
-    "__title__", "__summary__", "__uri__", "__version__", "__author__",
+    "__title__", "__summary__", "__url__", "__version__", "__author__",
     "__email__", "__license__", "__copyright__",
 ]
 
 __title__ = "swag-api"
 __summary__ = ("API service for SWAG data")
-__uri__ = "https://github.com/Netflix-Skunkworks/swag-api"
+__url__ = "https://github.com/Netflix-Skunkworks/swag-api"
 
-__version__ = "0.1.8"
+__version__ = "1.0.0"
 
 __author__ = "The SWAG developers"
 __email__ = "security@netflix.com"
 
 __license__ = "Apache License, Version 2.0"
-__copyright__ = "Copyright 2017 {0}".format(__author__)
+__copyright__ = "Copyright 2020 {0}".format(__author__)

--- a/swag_api/__init__.py
+++ b/swag_api/__init__.py
@@ -17,11 +17,11 @@ import swag_api.resources.provider      # noqa: F401
 import swag_api.resources.services      # noqa: F401
 from swag_api.__about__ import (
     __author__, __copyright__, __email__, __license__, __summary__, __title__,
-    __uri__, __version__
+    __url__, __version__
 )
 
 __all__ = [
-    "__title__", "__summary__", "__uri__", "__version__", "__author__",
+    "__title__", "__summary__", "__url__", "__version__", "__author__",
     "__email__", "__license__", "__copyright__",
 ]
 

--- a/swag_api/api.py
+++ b/swag_api/api.py
@@ -6,7 +6,7 @@
 .. moduleauthor:: Kevin Glisson <kglisson@netflix.com>
 """
 from flask import Blueprint
-from flask_restplus import Api
+from flask_restx import Api
 
 mod = Blueprint('api', __name__)
 api = Api(mod,

--- a/swag_api/parsers.py
+++ b/swag_api/parsers.py
@@ -6,7 +6,7 @@
 .. author:: Will Bengtson <wbengtson@netflix.com>
 """
 # Add request parsers to document the API in SWAGGER and do nice auto required field parsing in REST API
-from flask_restplus import reqparse
+from flask_restx import reqparse
 
 namespace_arguments = reqparse.RequestParser()
 namespace_arguments.add_argument('namespace', type=str, help='Namespace for SWAG (ex. accounts)')

--- a/swag_api/resources/accounts.py
+++ b/swag_api/resources/accounts.py
@@ -9,7 +9,7 @@
 from typing import Callable
 
 from flask import g, request, Response
-from flask_restplus import Resource
+from flask_restx import Resource
 from marshmallow.exceptions import ValidationError
 from swag_api.api import api
 from swag_api.extensions import swag

--- a/swag_api/resources/environment.py
+++ b/swag_api/resources/environment.py
@@ -9,7 +9,7 @@
 from typing import Callable
 
 from flask import g, request, Response
-from flask_restplus import Resource
+from flask_restx import Resource
 from swag_api.api import api
 from swag_api.extensions import swag
 from swag_api.parsers import env_arguments

--- a/swag_api/resources/namespace.py
+++ b/swag_api/resources/namespace.py
@@ -9,7 +9,7 @@
 from typing import Callable
 
 from flask import g, request, Response
-from flask_restplus import Resource
+from flask_restx import Resource
 from swag_api.api import api
 from swag_api.extensions import swag
 from swag_api.parsers import namespace_arguments

--- a/swag_api/resources/owner.py
+++ b/swag_api/resources/owner.py
@@ -9,7 +9,7 @@
 from typing import Callable
 
 from flask import g, request, Response
-from flask_restplus import Resource
+from flask_restx import Resource
 from swag_api.api import api
 from swag_api.extensions import swag
 from swag_api.parsers import owner_arguments

--- a/swag_api/resources/provider.py
+++ b/swag_api/resources/provider.py
@@ -9,7 +9,7 @@
 from typing import Callable
 
 from flask import g, request, Response
-from flask_restplus import Resource
+from flask_restx import Resource
 from swag_api.api import api
 from swag_api.extensions import swag
 from swag_api.parsers import provider_arguments

--- a/swag_api/resources/services.py
+++ b/swag_api/resources/services.py
@@ -9,7 +9,7 @@
 from typing import Callable
 
 from flask import g, request, Response
-from flask_restplus import Resource
+from flask_restx import Resource
 from marshmallow.exceptions import ValidationError
 from swag_api.api import api
 from swag_api.common.swag import get_account

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,linters
+envlist = py37,py38,linters
 
 [testenv]
 deps =


### PR DESCRIPTION
- Replaced flask_restplus with flast_restx as that has superseded it
- Upgraded swag_client to 3.0.0 which now requires Python 3

Python 2 support has ended in this relase! Please use 0.1.8 for
Python 2 support.