### PR TITLE
Added in support for ProxyFix to address Swagger mixed content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,30 @@ To create a custom metrics plugin, you will need to do the following:
 
 1. You can have multiple metrics plugins enabled should you want! `swag-api` will look for them on startup and initialize them. Feel free to add any initialization code you need
 in your class's `__init__()`.
+
+
+## Special Configuration
+This section covers other configuration options that are of importance.
+
+### Reverse Proxy Configuration
+If you are using a reverse proxy, like Apache or NGINX to front swag-api, then you will need to set the `SWAG_PROXIES` configuration value in your configuration file.
+This is required to prevent a situation where Swagger attempts to load it's data via HTTP instead of HTTPS resulting in a mixed-content error.
+
+`SWAG_PROXIES` is a dictionary (`Dict[str, int]`) that takes in the values that werkzeug provides for the [ProxyFix](https://werkzeug.palletsprojects.com/en/1.0.x/middleware/proxy_fix/#x-forwarded-for-proxy-fix) middleware.
+Here is an example that is sufficient to make Swagger happy:
+
+```python
+SWAG_PROXIES = {
+    'x_for': 1,  # These values should 1 or 0
+    'x_host': 1,
+}
+
+# The full list of values as documented in https://werkzeug.palletsprojects.com/en/1.0.x/middleware/proxy_fix/#x-forwarded-for-proxy-fix are:
+# x_for – Number of values to trust for X-Forwarded-For.
+# x_proto – Number of values to trust for X-Forwarded-Proto.
+# x_host – Number of values to trust for X-Forwarded-Host.
+# x_port – Number of values to trust for X-Forwarded-Port.
+# x_prefix – Number of values to trust for X-Forwarded-Prefix.
+```
+
+If you are not using a reverse proxy, then you can ingore this section.

--- a/swag_api/__about__.py
+++ b/swag_api/__about__.py
@@ -10,7 +10,7 @@ __title__ = "swag-api"
 __summary__ = ("API service for SWAG data")
 __url__ = "https://github.com/Netflix-Skunkworks/swag-api"
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 __author__ = "The SWAG developers"
 __email__ = "security@netflix.com"

--- a/swag_api/__init__.py
+++ b/swag_api/__init__.py
@@ -30,8 +30,8 @@ SWAG_API_BLUEPRINTS = (
 )
 
 
-def create_app(config=None) -> Flask:
-    app = factory.create_app(app_name=__name__, blueprints=SWAG_API_BLUEPRINTS, config=None)
+def create_app(app_name: str = __name__, config: str = None) -> Flask:
+    app = factory.create_app(app_name=app_name, blueprints=SWAG_API_BLUEPRINTS, config=config)
     return app
 
 

--- a/swag_api/tests/conftest.py
+++ b/swag_api/tests/conftest.py
@@ -114,6 +114,16 @@ def swag_app(dynamodb_table) -> Flask:
     yield app
 
 
+@pytest.yield_fixture(scope='function')
+def swag_proxy_app(dynamodb_table) -> Flask:
+    from swag_api import create_app
+
+    app = create_app(config=os.path.join(os.path.dirname(os.path.realpath(__file__)), 'default_proxy_test.conf.py'))
+    app.app_context()
+
+    yield app
+
+
 @pytest.fixture(scope='function')
 def swag_app_client(swag_app: Flask) -> FlaskClient:
     yield swag_app.test_client()

--- a/swag_api/tests/default_proxy_test.conf.py
+++ b/swag_api/tests/default_proxy_test.conf.py
@@ -1,0 +1,17 @@
+LOG_LEVEL = "DEBUG"
+
+debug = True
+
+SECRET_KEY = 'supersupersupersecret'
+
+# Disable this in your environment:
+ENABLE_SAMPLE_METRICS_PLUGIN = True
+
+# Enable Reverse Proxy support:
+SWAG_PROXIES = {
+    'x_for': 1,
+    'x_proto': 1,
+    'x_host': 1,
+    'x_port': 0,
+    # 'x_prefix': 0  # This should default to 0 in the test.
+}


### PR DESCRIPTION
- Added in support for reverse proxy configuration.
- This can be used to resolve a mixed content (HTTP/HTTPS) issue with
  Swagger